### PR TITLE
Fix varinit on global const blocks

### DIFF
--- a/src/varinit/testdata/globalconst/globalConst.go
+++ b/src/varinit/testdata/globalconst/globalConst.go
@@ -1,0 +1,15 @@
+package globalconst
+
+const (
+	Foo = iota
+	Bar
+	Baz
+)
+
+func consume(x int) {}
+
+func main() {
+	consume(Foo)
+	consume(Bar)
+	consume(Baz)
+}

--- a/src/varinit/varinit.go
+++ b/src/varinit/varinit.go
@@ -116,6 +116,9 @@ func EvalVarDecl(c *Context, valSpec *ast.ValueSpec) {
 }
 
 func EvalVarDeclBlock(c *Context, d *ast.GenDecl) {
+	if d.Tok == token.CONST {
+		return
+	}
 	for _, spec := range d.Specs {
 		valSpec, isValSpec := spec.(*ast.ValueSpec)
 		if !isValSpec {


### PR DESCRIPTION
The `varinit` linter reports false negative results against global const blocks where constants are defined with `iota` - in that case constants after `iota` would have no initializer. This commit skips global const blocks entirely, because

- if `iota` is used, constants are indeed initialized
- constants not covered by `iota` and without an initializer will not compile