### PR TITLE
varinit: Fix missed switch (missing default) branch cases

### DIFF
--- a/src/allfields/allfields_test.go
+++ b/src/allfields/allfields_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestAnalyzers(t *testing.T) {
 	allFieldsAnalyzer := New()
-	testutils.RunTests(t, allFieldsAnalyzer)
+	testutils.RunTests(t, allFieldsAnalyzer, nil)
 }

--- a/src/capturederr/capturedErr_test.go
+++ b/src/capturederr/capturedErr_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAnalyzers(t *testing.T) {
-	testutils.RunTests(t, New())
+	testutils.RunTests(t, New(), nil)
 }

--- a/src/explicitcast/explicitcast_test.go
+++ b/src/explicitcast/explicitcast_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAnalyzers(t *testing.T) {
-	testutils.RunTests(t, New())
+	testutils.RunTests(t, New(), nil)
 }

--- a/src/testutils/testUtils.go
+++ b/src/testutils/testUtils.go
@@ -8,17 +8,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/upsun/vinego/src/utils"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-func RunTests(t *testing.T, analyzer *analysis.Analyzer) {
+func RunTests(t *testing.T, analyzer *analysis.Analyzer, filter map[string]bool) {
 	root := "testdata"
 	err := filepath.Walk(root, func(path string, info fs.FileInfo, err0 error) error {
 		if err0 != nil {
 			return err0
 		}
 		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if filter != nil && !filter[utils.Last(strings.Split(path, "/"))] {
 			return nil
 		}
 		contents, err := os.ReadFile(path)

--- a/src/varinit/testdata/switchdefaultbad/switchDefaultBad.go
+++ b/src/varinit/testdata/switchdefaultbad/switchDefaultBad.go
@@ -6,6 +6,8 @@ func consume(x int) {}
 func main() {
 	var x int
 	switch produce() {
+	case 3:
+		x = 2
 	case 4:
 		x = 7
 	default:

--- a/src/varinit/testdata/switchnesteddefaultbad/switchNestedDefaultBad.go
+++ b/src/varinit/testdata/switchnesteddefaultbad/switchNestedDefaultBad.go
@@ -1,4 +1,4 @@
-package switchnodefault
+package switchnesteddefaultbad
 
 func produce() int  { return 7 }
 func consume(x int) {}
@@ -7,9 +7,15 @@ func main() {
 	var x int
 	switch produce() {
 	case 3:
-		x = 1
+		//
+		x = 2
 	case 4:
-		x = 3
+		switch produce() {
+		case 5:
+			x = 7
+		}
+	default:
+		x = 4
 	}
 	consume(x) // want "x"
 }

--- a/src/varinit/varinit.go
+++ b/src/varinit/varinit.go
@@ -329,12 +329,13 @@ func EvalFunc(
 	deps := map[*cfg.Block][]*cfg.Block{}
 	unordered := map[int32]*cfg.Block{}
 	for _, b := range flow.Blocks {
-		// Skip unreachable blocks... because they're unreachable
+		// Skip unreachable blocks... they might not be fully initialized
 		if !b.Live {
 			continue
 		}
 
-		// Break for loop loopiness, treat them like ifs since that's how they decompose
+		// Break for loop loopiness, iteration 2+ has same analysis as 1st
+		// so we can skip the back-link
 		if b.Kind == cfg.KindForLoop {
 			newSuccs := []*cfg.Block{}
 			for _, succ := range b.Succs {

--- a/src/varinit/varinit_test.go
+++ b/src/varinit/varinit_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAnalyzers(t *testing.T) {
-	testutils.RunTests(t, New())
+	testutils.RunTests(t, New(), nil)
 }


### PR DESCRIPTION
Background: For varinit we do control flow graph (CFG) analysis - basically turning the code into a graph connected with links to branch/jump statements.  Then we walk the graph from when a variable is declared through all downstream branches to where it's used and alert if any of them missed initialization.

The branch analysis depth-ordering was bad, it was putting the nested branch blocks after the return block so the fact that a var wasn't initialized in them was missed.  I think it might not have been deterministic (at least, per the interface spec) so adding random extra blocks to various test cases caused different orderings which eventually exposed it.

I think I originally had this complex implementation to avoid dealing with "for loops" which cause the CFG to have cycles, but since there was a bug I decided to rewrite it:  This time I manually broke for loops using a simple recursive walk while remembering handled and partially-handled blocks... this seems to have worked and the code is much cleaner.

The one trick is that if there's a loop the first looped block gets added to the block "seen" lookup with `nil` instead of data - if we encounter that we assume we're in a loop due to a `for` or `goto` (?) and ignore it, which I hope is an accurate heuristic.

Changes:
- Modify test util function to allow whitelisting test cases to make debugging more specific
- Add new varinit test cases/branches to existing switch test cases
- Rewrite CFG walk - now 2 stages instead of 3, using a recursive function