### PR TITLE
Enforce / Support go 1.25

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm
+FROM golang:1.25-bookworm
 ADD . /src
 WORKDIR /src
 ENV GOPATH=/install
@@ -13,7 +13,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN go install honnef.co/go/tools/cmd/staticcheck@latest
 
-FROM golang:1.24-bookworm
+FROM golang:1.25-bookworm
 COPY --from=0 /install/bin/* /bin/
 COPY --from=0 /src/custom-gcl /bin/golangci-lint
 RUN chmod +x /bin/*

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/upsun/vinego/src
 
-go 1.24
+go 1.25
 
 require golang.org/x/tools v0.31.0
 


### PR DESCRIPTION
Hopefully nothing break, support for go 1.25 on the docker build
Enforce it in go.mod 