### PR TITLE
Use golang trixie as base docker image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm
+FROM golang:1.25-trixie
 ADD . /src
 WORKDIR /src
 ENV GOPATH=/install
@@ -13,7 +13,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN go install honnef.co/go/tools/cmd/staticcheck@latest
 
-FROM golang:1.25-bookworm
+FROM golang:1.25-trixie
 COPY --from=0 /install/bin/* /bin/
 COPY --from=0 /src/custom-gcl /bin/golangci-lint
 RUN chmod +x /bin/*


### PR DESCRIPTION
Trixie is the new debian version, we should use this one now