### PR TITLE
Remove unused utility functions

### DIFF
--- a/src/capturederr/capturedErr.go
+++ b/src/capturederr/capturedErr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"slices"
 
 	"golang.org/x/tools/go/analysis"
 
@@ -14,7 +15,7 @@ func New() *analysis.Analyzer {
 	return &analysis.Analyzer{
 		Name: "capturederr",
 		Doc:  "_",
-		Run: func(p *analysis.Pass) (interface{}, error) {
+		Run: func(p *analysis.Pass) (any, error) {
 			for _, file := range p.Files {
 				// check:allfields
 				type Layer struct {
@@ -38,10 +39,8 @@ func New() *analysis.Analyzer {
 								return
 							}
 							layer := utils.Last(stack)
-							for _, v := range layer.Declarations {
-								if decl.Pos() == v {
-									return
-								}
+							if slices.Contains(layer.Declarations, decl.Pos()) {
+								return
 							}
 							p.Report(analysis.Diagnostic{
 								Pos:     ident.Pos(),

--- a/src/explicitcast/explicitcast.go
+++ b/src/explicitcast/explicitcast.go
@@ -46,7 +46,7 @@ func New() *analysis.Analyzer {
 	return &analysis.Analyzer{
 		Name: "explicitcast",
 		Doc:  "_",
-		Run: func(p *analysis.Pass) (interface{}, error) {
+		Run: func(p *analysis.Pass) (any, error) {
 			checkLit := func(p *analysis.Pass, t types.Type, e ast.Expr) {
 				basicLit, isBasicLit := e.(*ast.BasicLit)
 				if !isBasicLit {
@@ -128,7 +128,7 @@ func New() *analysis.Analyzer {
 						}
 						var inFunc *types.Signature = nil
 					FindFunc:
-						for i := 0; i < len(crumbs); i++ {
+						for i := range crumbs {
 							crumb := crumbs[len(crumbs)-1-i]
 							switch f := crumb.(type) {
 							case *ast.FuncDecl:

--- a/src/utils/scanTypeTags.go
+++ b/src/utils/scanTypeTags.go
@@ -26,7 +26,7 @@ func ScanTypeTags(p *analysis.Pass) {
 				return true
 			}
 			enabledChecks := &ChecksFact{}
-			for _, line := range strings.Split(decl.Doc.Text(), "\n") {
+			for line := range strings.SplitSeq(decl.Doc.Text(), "\n") {
 				matches := checkRegexp.FindStringSubmatch(line)
 				if len(matches) >= 2 {
 					(*enabledChecks)[matches[1]] = true

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -5,23 +5,8 @@ import (
 	"maps"
 )
 
-//go:fix inline
-func P[V any](v V) *V {
-	return new(v)
-}
-
 func Append[E any](d *[]E, v ...E) {
 	*d = append(*d, v...)
-}
-
-func Remove[E any](d *[]E, start int, count int) {
-	*d = append((*d)[:start], (*d)[start+count:]...)
-}
-
-func PopMap[K comparable, V any](m map[K]V, key K) V {
-	out := m[key]
-	delete(m, key)
-	return out
 }
 
 func UpdateMap[K comparable, V any](
@@ -42,11 +27,6 @@ func MergeMap[K comparable, V any](
 
 func Last[V any](v []V) V {
 	return v[len(v)-1]
-}
-
-// ArrAntiSuffix returns all but count last elements
-func ArrAntiSuffix[V any](v []V, count int) []V {
-	return v[:len(v)-count]
 }
 
 type walkPair[S any] struct {

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -2,10 +2,12 @@ package utils
 
 import (
 	"go/ast"
+	"maps"
 )
 
+//go:fix inline
 func P[V any](v V) *V {
-	return &v
+	return new(v)
 }
 
 func Append[E any](d *[]E, v ...E) {
@@ -35,9 +37,7 @@ func MergeMap[K comparable, V any](
 	dest map[K]V,
 	source map[K]V,
 ) {
-	for k, v := range source {
-		dest[k] = v
-	}
+	maps.Copy(dest, source)
 }
 
 func Last[V any](v []V) V {

--- a/src/varinit/varinit.go
+++ b/src/varinit/varinit.go
@@ -256,7 +256,6 @@ func MergeScopes(block *cfg.Block, inputs []*Scope) *Scope {
 	uninitialized := map[VarId]*Decl{}
 	for _, depScope := range inputs {
 		for vid, branchDecl := range depScope.Uninitialized {
-			branchDecl := branchDecl
 			utils.UpdateMap(uninitialized, vid, func(v *Decl, exists bool) *Decl {
 				if v == nil {
 					v = &Decl{
@@ -271,9 +270,7 @@ func MergeScopes(block *cfg.Block, inputs []*Scope) *Scope {
 		}
 	}
 	for _, depScope := range inputs {
-		depScope := depScope
 		for vid, branchDecl := range depScope.Uninitialized {
-			branchDecl := branchDecl
 			utils.UpdateMap(uninitialized, vid, func(v *Decl, exists bool) *Decl {
 				if v.Changed {
 					if branchDecl.Changed {
@@ -491,7 +488,7 @@ func New() *analysis.Analyzer {
 		Name:     "varinit",
 		Doc:      "_",
 		Requires: []*analysis.Analyzer{ctrlflow.Analyzer},
-		Run: func(p *analysis.Pass) (interface{}, error) {
+		Run: func(p *analysis.Pass) (any, error) {
 			cfgs := p.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 			reported := map[VarId]bool{}
 			for _, file := range p.Files {


### PR DESCRIPTION
## Summary
- Remove unused functions `P`, `Remove`, `PopMap`, and `ArrAntiSuffix` from `utils/utils.go`

## Test plan
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)